### PR TITLE
Added Frankfurt am Main

### DIFF
--- a/directory/directory.json
+++ b/directory/directory.json
@@ -7,6 +7,7 @@
 	"chemnitz" : "http://api.routers.chemnitz.freifunk.net/request.php?apikey=f666e95f44c2a54c90f408a2043e30d970fc5f1b&type=com.ffc.info.general",
 	"dresden" : "http://info.ddmesh.de/info/freifunk.json",
 	"franken" : "https://raw.github.com/mojoaxel/freifunkfranken-community/master/freifunkfranken.json",
+	"frankfurt_am_main" : "http://kdserv.dyndns.org/ff-frankfurt.json",
 	"gadow" : "http://feeds.leipzig.freifunk.net/ffapi/gadow.json",
 	"gronau" : "http://freifunk.liztv.net/ffapi/gronau.json",
 	"grossdraxdorf" : "http://feeds.leipzig.freifunk.net/ffapi/grossdraxdorf.json",


### PR DESCRIPTION
Ahoi,
hier die Config für das FreifunkNetz in Frankfurt am Main.
Grüße und Dank, Ralf

PS: Falls die von uns ausgelieferte JSON-Datei von Interesse ist, die ist auch hier zu finden: https://github.com/freifunk-ffm/community.json
