### PR TITLE
changed URL of frankfurt_am_main

### DIFF
--- a/directory/directory.json
+++ b/directory/directory.json
@@ -9,7 +9,7 @@
 	"franken" : "https://raw.github.com/FreifunkFranken/freifunkfranken-community/master/freifunkfranken.json",
 	"fuerth" : "https://raw.github.com/FreifunkFranken/freifunkfranken-community/master/freifunkfuerth.json",
 	"unfinden" : "https://raw.github.com/FreifunkFranken/freifunkfranken-community/master/freifunkunfinden.json",
-	"frankfurt_am_main" : "http://kdserv.dyndns.org/ff-frankfurt.json",
+	"frankfurt_am_main" : "http://freifunk-ffm.github.io/community.json/ff-frankfurt.json",
 	"gadow" : "http://feeds.leipzig.freifunk.net/ffapi/gadow.json",
 	"gronau" : "http://freifunk.liztv.net/ffapi/gronau.json",
 	"grossdraxdorf" : "http://feeds.leipzig.freifunk.net/ffapi/grossdraxdorf.json",


### PR DESCRIPTION
Due to trouble with dyndns we have to change the URL of our community.json temporarily to some more reliable place. ;-)
