### PR TITLE
added development JSON File

### DIFF
--- a/specs/development.json
+++ b/specs/development.json
@@ -1,15 +1,15 @@
 {
 	"schema": {
 		"type": "object",
-		"description": "Freifunk Community API 0.3.1",
+		"description": "Freifunk Community API X.X.X",
 		"required": false,
 		"properties": {
 			"api": {
 				"title": "API",
 				"type": "string",
 				"description": "The Freifunk Community API version you use",
-				"enum": ["0.1", "0.2.0", "0.2.1", "0.3.0", "0.3.1"],
-				"default": "0.3.1",
+				"enum": ["0.1", "0.2.0", "0.2.1", "0.3.0", "0.3.1", "X.X.X"],
+				"default": "X.X.X",
 				"required": true
 			},
 			"name": {


### PR DESCRIPTION
We should use the new specification file _specs/development.json_ for new changes > 0.3.1.
After something in the specification changed we can create a new version from this file and add a copy to the generator folder. This makes parallel development easier and more transparent.
