### PR TITLE
Add ?join to jabber pattern

### DIFF
--- a/specs/0.4.5.json
+++ b/specs/0.4.5.json
@@ -118,7 +118,7 @@
 					"jabber": {
 						"title": "Jabber",
 						"type": "string",
-						"pattern": "^[A-Za-z0-9äöüÄÖUß_\\-\\.]+@[A-Za-z0-9äöüÄÖUß_\\-\\.]+\\.[A-Za-z]{2,}(\\?join){0,1}$",
+						"pattern": "^[A-Za-z0-9äöüÄÖUß_\\-\\.]+@[A-Za-z0-9äöüÄÖUß_\\-\\.]+\\.[A-Za-z]{2,}$",
 						"description": "a jabber account someone reads (account@jabberserver.tld)",
 						"required": false
 					},

--- a/specs/0.4.5.json
+++ b/specs/0.4.5.json
@@ -118,7 +118,7 @@
 					"jabber": {
 						"title": "Jabber",
 						"type": "string",
-						"pattern": "^[A-Za-z0-9äöüÄÖUß_\\-\\.]+@[A-Za-z0-9äöüÄÖUß_\\-\\.]+\\.[A-Za-z]{2,}$",
+						"pattern": "^[A-Za-z0-9äöüÄÖUß_\\-\\.]+@[A-Za-z0-9äöüÄÖUß_\\-\\.]+\\.[A-Za-z]{2,}(\\?join){0,1}$",
 						"description": "a jabber account someone reads (account@jabberserver.tld)",
 						"required": false
 					},

--- a/specs/development.json
+++ b/specs/development.json
@@ -118,7 +118,7 @@
 					"jabber": {
 						"title": "Jabber",
 						"type": "string",
-						"pattern": "^[A-Za-z0-9äöüÄÖUß_\\-\\.]+@[A-Za-z0-9äöüÄÖUß_\\-\\.]+\\.[A-Za-z]{2,}$",
+						"pattern": "^[A-Za-z0-9äöüÄÖUß_\\-\\.]+@[A-Za-z0-9äöüÄÖUß_\\-\\.]+\\.[A-Za-z]{2,}(\\?join){0,1}$",
 						"description": "a jabber account someone reads (account@jabberserver.tld)",
 						"required": false
 					},


### PR DESCRIPTION
The jabber contact for our community is
"xmpp:noklab@muc.cccgoe.de?join“. The „?join“ is necessary because it
is a multi user chat contact. 