### PR TITLE
added ircs:// as valid uri scheme

### DIFF
--- a/specs/development.json
+++ b/specs/development.json
@@ -111,7 +111,7 @@
 					"irc": {
 						"title": "IRC",
 						"type": "string",
-						"pattern": "^irc://.*",
+						"pattern": "^(irc|ircs)://.*",
 						"description": "your community's irc channel, starts with irc://",
 						"required": false
 					},


### PR DESCRIPTION
ffmuc uses Secure IRC (ircs) - it is a valid uri scheme (see http://en.wikipedia.org/wiki/URI_scheme)