### PR TITLE
fixed typo in section "technical Details"

### DIFF
--- a/specs/development.json
+++ b/specs/development.json
@@ -576,7 +576,7 @@
 								"nameserver": {
 									"type": "array",
 									"title": "Nameserver",
-									"description": "Nameservers servings zones of your domain",
+									"description": "Nameservers serving zones of your domain",
 									"required": false,
 									"items": {
 										"type": "string",


### PR DESCRIPTION
In the section "Technical Details" under "Domain Names" the descriptive sentence "Nameservers servings zones of your domain" got a typo.
Correct would be "serving zones", without the second 's' in serving.