### PR TITLE
Added wecanhelp as a new provider to the enum. #163

### DIFF
--- a/specs/development.json
+++ b/specs/development.json
@@ -465,8 +465,10 @@
                                         "type": "string",
                                         "title": "Campaign Providers",
                                         "description": "Where do you host your donations?",
-                                        "enum": [ "", "betterplace", "boost" ],
-                                        "default": ""
+                                        "enum": ["", "betterplace", "wecanhelp"],
+       					"default": "",
+        				"deprecated": true,
+        				"deprecatedDescription": "This provider is deprecated and will be removed in a future version."
                                     },
                                     "projectid": {
                                         "type": "string",


### PR DESCRIPTION
Marked boost as "depricated" and added "wecanhelp" as a new provider to the enum.